### PR TITLE
Websockets now use `wss` whenever `https` is used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 Development
 -----------
+* Websockets now use wss whenever https is used
 
 1.0.1 (2021-09-15)
 ------------------

--- a/planning_poker/assets/js/poker-session.js
+++ b/planning_poker/assets/js/poker-session.js
@@ -22,10 +22,10 @@ let app = new Vue({
   },
 });
 
-let ws_scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+let wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
 
 Vue.prototype.$consumer = new PokerConsumer(
-  document.body.querySelector('#app'), `${ws_scheme}://${host}/poker/${pokerSessionId}/`, userId
+  document.body.querySelector('#app'), `${wsScheme}://${host}/poker/${pokerSessionId}/`, userId
 );
 
 //Find the PokerSite component, which has access to the different $refs of the other components.

--- a/planning_poker/assets/js/poker-session.js
+++ b/planning_poker/assets/js/poker-session.js
@@ -22,8 +22,10 @@ let app = new Vue({
   },
 });
 
+let ws_scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+
 Vue.prototype.$consumer = new PokerConsumer(
-  document.body.querySelector('#app'), `ws://${host}/poker/${pokerSessionId}/`, userId
+  document.body.querySelector('#app'), `${ws_scheme}://${host}/poker/${pokerSessionId}/`, userId
 );
 
 //Find the PokerSite component, which has access to the different $refs of the other components.

--- a/planning_poker/routing.py
+++ b/planning_poker/routing.py
@@ -3,5 +3,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r'/(?P<poker_session>\d+)/$', consumers.PokerConsumer.as_asgi()),
+    re_path(r'poker/(?P<poker_session>\d+)/$', consumers.PokerConsumer.as_asgi()),
 ]

--- a/tests/planning_poker/test_consumers.py
+++ b/tests/planning_poker/test_consumers.py
@@ -18,7 +18,7 @@ class TestPokerConsumer:
         if has_active_story:
             poker_session.active_story = story
             await database_sync_to_async(poker_session.save)()
-        communicator = WebsocketCommunicator(application, 'ws://test/planning_poker/{}/'.format(poker_session.id))
+        communicator = WebsocketCommunicator(application, 'ws://test/poker/{}/'.format(poker_session.id))
         connected, subprotocol = await communicator.connect()
         assert connected
         if has_active_story:


### PR DESCRIPTION
# Description
During internal use the problem arose that the app can't be used over `https`. This is because the connection to the websockets is always made over `ws`, which will be blocked by browsers due to a mixed content error.
This PR solves this issue by either using `ws` or `wss` for the websocket connection depending on the protocol used visiting the site.

# Testing

1. Set up a local server to which you can connect to via `http` and `https`
2. Create two users and a poker session
        2.1. Use one user to connect to the session via `http`
        2.2. Use the other user to connect to the session via `https`
3. Simulate a session by voting for stories/changing the active story, etc.
4. Make sure, that all the expected thing happen (for both the `http` and `https` user)