### PR TITLE
Add Trusted Publisher Management workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,13 @@ on:
 
 jobs:
   publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: production
+      url: https://pypi.org/project/planning-poker/
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -28,8 +33,5 @@ jobs:
       run: |
         django-admin compilemessages
         python setup.py sdist bdist_wheel
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.4
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,13 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '12'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -31,19 +31,20 @@ jobs:
       run: coverage xml
       if: ${{ success() }}
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         files: coverage.xml
         flags: unittests
+        token: ${{ secrets.CODECOV_TOKEN }}
       if: ${{ success() }}
 
   js-tests:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '12'
     - name: Install dependencies
@@ -51,8 +52,9 @@ jobs:
     - name: Run tests
       run: npm run test:coverage
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage/cobertura-coverage.xml
         flags: unittests
+        token: ${{ secrets.CODECOV_TOKEN }}
       if: ${{ success() }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Development
 -----------
 
+* Changed publish workflow to match the Trusted Publisher Management in PyPI
 * Updated Django requirement
 
 1.0.3 (2022-09-01)


### PR DESCRIPTION
This PR changes the "publish" workflow to work with the Trusted Publisher Management, see

- https://docs.pypi.org/trusted-publishers/
- https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

A manual test can only be done with a separate and modified workflow. But I have tested the upload to Test PyPI within another project, see https://github.com/rheinwerk-verlag/pganonymize/actions/runs/8284252773